### PR TITLE
enabling testing on node 0.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ node_js:
   - "6"
   - "5"
   - "4"
-  - "0"
+  - "0.12"
+  - "0.10"
 addons:
   code_climate:
     repo_token: 79816a32349b15a909e262a88676bf1d51021ad6848b96706411bb2b829dd5b6


### PR DESCRIPTION
The way the travis file is defined, it was only running on node 0.12. I added 0.10 as well, to officially test support.

Tests fail, but I'ma submit this anyway so we can talk about it.